### PR TITLE
fix logback async configuration

### DIFF
--- a/src/main/resources/async/logback-file.xml
+++ b/src/main/resources/async/logback-file.xml
@@ -7,8 +7,10 @@
       <pattern>%d %p [%logger] %m%n</pattern>
     </encoder>
   </appender>
-  <appender name="Async" class="ch.qos.logback.classic.AsyncAppender" queueSize="1000000" discardingThreshold="0">
+  <appender name="Async" class="ch.qos.logback.classic.AsyncAppender">
   	<appender-ref ref="File" />
+    <queueSize>1000000</queueSize>
+    <discardingThreshold>0</discardingThreshold>
   </appender>
   <root level="all">
     <appender-ref ref="Async" />

--- a/src/main/resources/async/logback-syslog-udp.xml
+++ b/src/main/resources/async/logback-syslog-udp.xml
@@ -4,8 +4,10 @@
     <port>514</port>
     <facility>LOCAL7</facility>
   </appender>
-  <appender name="Async" class="ch.qos.logback.classic.AsyncAppender" queueSize="1000000" discardingThreshold="0">
+  <appender name="Async" class="ch.qos.logback.classic.AsyncAppender">
   	<appender-ref ref="Syslog" />
+    <queueSize>1000000</queueSize>
+    <discardingThreshold>0</discardingThreshold>
   </appender>
   <root level="all">
     <appender-ref ref="Async" />


### PR DESCRIPTION
The configuration parameters for the Logback AsyncAppender were attributes, when they should have been separate nodes. This change causes the Logback async tests to no longer drop messages (with the expected performance hit).